### PR TITLE
Optimize newChunk()

### DIFF
--- a/fastcdc.go
+++ b/fastcdc.go
@@ -185,15 +185,22 @@ func (c *Chunker) Next() (Chunk, error) {
 
 func (c *Chunker) nextChunk(data []byte) (int, uint64) {
 	fp := uint64(0)
-	i := c.minSize
+	n  := len(data)
 
-	if len(data) <= c.minSize {
-		return len(data), fp
+	if n <= c.minSize {
+		return n, fp
 	}
 
-	n := min(len(data), c.maxSize)
+	i := c.minSize
+	m := c.normSize
+	if n > c.maxSize {
+		n = c.maxSize
+	}
+	if n < c.normSize {
+		m = n
+	}
 
-	for ; i < min(n, c.normSize); i++ {
+	for ; i < m; i++ {
 		fp = (fp << 1) + table[data[i]]
 		if (fp & c.maskS) == 0 {
 			return i + 1, fp
@@ -235,12 +242,6 @@ func (opts Options) validate() error {
 	return nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 // 256 random uint64s for the rolling hash function
 var table [256]uint64 = [256]uint64{


### PR DESCRIPTION
Some reorganization can somewhat improve the performance of nextChunk(). This also makes function min() redundant.

```
name     old time/op   new time/op   delta
FastCDC    1.85s ± 0%    1.68s ± 1%  -8.99%  (p=0.000 n=10+10)

name     old speed     new speed     delta
FastCDC  567MB/s ± 0%  623MB/s ± 1%  +9.87%  (p=0.000 n=10+10)
```

Signed-off-by: Grzegorz Kowal <grzegorz@amuncode.org>