### PR TITLE
Skip re-computing gear table when seed is zero

### DIFF
--- a/fastcdc.go
+++ b/fastcdc.go
@@ -106,8 +106,10 @@ func NewChunker(rd io.Reader, opts Options) (*Chunker, error) {
 		return nil, err
 	}
 
-	for i := 0; i < len(table); i++ {
-		table[i] = table[i] ^ opts.Seed
+	if opts.Seed != 0 {
+		for i := 0; i < len(table); i++ {
+			table[i] = table[i] ^ opts.Seed
+		}
 	}
 
 	normalization := opts.Normalization


### PR DESCRIPTION
When the seed is zero `table[i] = table[i] ^ opts.Seed` is a no-op. Skipping it allows us to use the chunker in parallel when the seed is zero. Otherwise it will lead to a race condition when different go routines change the global table variable.